### PR TITLE
Adding null check to textAnyCase, fixes error when parsing sequences

### DIFF
--- a/myna.ts
+++ b/myna.ts
@@ -662,9 +662,11 @@ export namespace Myna
                 vals.push(text[i]);
             this.lexer = (p : ParseState) => {
                 let index = p.index; 
-                for (let val of vals)
-                    if (p.input[index++].toLowerCase() !== val) 
+                for (let val of vals) {
+                    var inp = p.input[index++];
+                    if (!inp || inp.toLowerCase() !== val) 
                         return false;
+                }
                 p.index = index;
                 return true;
             }

--- a/tests/rule_tester.js
+++ b/tests/rule_tester.js
@@ -1,7 +1,7 @@
 "use strict";
 
 // This class tests parser rules given an array of inputs. 
-// Each input is an array [rule, [passing inputs], [failint inputs]]
+// Each input is an array [rule, [passing inputs], [failing inputs]]
 // The TestRunner is a function like QUnit.test 
 function RuleTester(myna, inputs, testRunner)
 {    


### PR DESCRIPTION
Looks like when using `textAnyCase` in a sequence, `p.input[index++]` is undefined at the end of the sequence.  I'm guessing because the remaining input length is less than the `vals` length.

This PR adds a null check for `p.input[index++]` (might also be able to check for `index++ > p.input.length`).

I would have liked to add a test as well but I don't see where you are testing sequences.